### PR TITLE
animacje z interpolacja

### DIFF
--- a/AI_Project/Assets/RTS Mini Legion Lich/Animations/Lich/Lich.controller
+++ b/AI_Project/Assets/RTS Mini Legion Lich/Animations/Lich/Lich.controller
@@ -310,7 +310,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.15
   m_TransitionOffset: 0
   m_ExitTime: 0.8125
   m_HasExitTime: 0
@@ -490,7 +490,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.15
   m_TransitionOffset: 0
   m_ExitTime: 0.625
   m_HasExitTime: 0
@@ -514,7 +514,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.15
   m_TransitionOffset: 0
   m_ExitTime: 0.8125
   m_HasExitTime: 1
@@ -562,7 +562,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.15
   m_TransitionOffset: 0
   m_ExitTime: 0.8125
   m_HasExitTime: 0


### PR DESCRIPTION
Płynniej przechodzą ale jak się wciśnie i przytrzyma np. W a potem tylko kliknie -> (strzałkę w prawo) tak szybko (mniej jak 0.15s) i od razu po wciśnięciu W, to animacja się nie załączy, a atak poleci i postać "mrugnie". Jeśli przesadzam i to nie jest bug (bo trzeba się postarać by to zaszło) to poproszę o zatwierdzenie bo animacje będą lepiej przechodziły.